### PR TITLE
Non object returns meta fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,14 +49,16 @@ var Client = module.exports = function(config) {
                    }
 
                    if (!ret) ret = {};
-                   if (!ret.meta) ret.meta = {};
+                   if (typeof ret ==="object") {
+                     if (!ret.meta) ret.meta = {};
 
-                   // TODO: Roll the rate limiting values into the API call to make
-                   // it more transprent when an issue arrises.
+                     // TODO: Roll the rate limiting values into the API call to make
+                     // it more transprent when an issue arrises.
 
-                   ["x-ratelimit-limit", "x-ratelimit-remaining", "x-oauth-scopes", "link"].forEach(function(header) {
-                       if (res.headers[header]) ret.meta[header] = res.headers[header];
-                   });
+                     ["x-ratelimit-limit", "x-ratelimit-remaining", "x-oauth-scopes", "link"].forEach(function(header) {
+                         if (res.headers[header]) ret.meta[header] = res.headers[header];
+                     });
+                   }
                    if (callback) callback(null, ret);
                });
            };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "braque",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "author": {
     "name": "Stephan Smith",
     "email": "Stephan.Smith.BC93@gmail.com"


### PR DESCRIPTION
A simple fix in case an api return is not an object, but is instead a core type interpreted by ```JSON.parse```.